### PR TITLE
Initialize reference architectures workstream scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.claude/

--- a/workstreams/reference-architecture/README.md
+++ b/workstreams/reference-architecture/README.md
@@ -1,0 +1,35 @@
+# Reference Architecture Workstream
+
+Workflows & Process Integration WG · Agentic AI Foundation
+
+## What
+
+A composable catalog of independently adoptable components for agentic workflows, plus one reference architecture per use case. Components first; architectures derived from use cases. Not a monolithic RA. Charter deliverable target: 08.01.2026.
+
+## Structure
+
+```
+./catalog/component-catalog.md   Component blocks, defined once
+./ra/ra-<use-case>.md            One RA per use case
+./templates/ra-template.md       Copy to start a new RA
+./decisions/decision-log.md      Decisions + dates
+```
+
+RA files reference catalog blocks — they don't redefine them.
+
+## How we work
+
+- Async first. Google Doc = scratchpad; GitHub = artifacts.
+- Promote a Doc item to a PR once it has an owner.
+- Discussion on the PR. Every artifact has one owner.
+- Abstraction = components + relationships, not implementation. Properties, not mechanisms.
+
+## Contribute
+
+Request repo access in the WG Discord. Copy the template → open a PR → discuss on the PR. Decisions logged in `./decisions/`.
+
+## Links
+
+- WG repo: https://github.com/aaif/wg-workflows-and-process-integration
+- Google Doc: https://docs.google.com/document/d/1g8637JPZZ4Y-V-KXTcGU0de1HmTEc2iI6-PCTHv7zuI/edit?tab=t.s4e90o73aqx5#heading=h.71q4tygpnbxa
+- Discord: https://discord.com/channels/1461090924791595243/1504501906251452478

--- a/workstreams/reference-architecture/README.md
+++ b/workstreams/reference-architecture/README.md
@@ -19,7 +19,7 @@ RA files reference catalog blocks — they don't redefine them.
 
 ## How we work
 
-- Async first. Google Doc = scratchpad; GitHub = artifacts.
+- Async first. Discord = ideas; Google Doc = proposals; GitHub = artifacts.
 - Promote a Doc item to a PR once it has an owner.
 - Discussion on the PR. Every artifact has one owner.
 - Abstraction = components + relationships, not implementation. Properties, not mechanisms.

--- a/workstreams/reference-architecture/README.md
+++ b/workstreams/reference-architecture/README.md
@@ -20,8 +20,8 @@ RA files reference catalog blocks — they don't redefine them.
 ## How we work
 
 - Async first. Discord = ideas; Google Doc = proposals; GitHub = artifacts.
-- Promote a Doc item to a PR once it has an owner.
-- Discussion on the PR. Every artifact has one owner.
+- Contributions happen through PRs: fork the repo, propose changes, discuss on the PR, and merge when ready.
+- Keep artifacts easy to maintain by making ownership clear where useful.
 - Abstraction = components + relationships, not implementation. Properties, not mechanisms.
 
 ## Contribute

--- a/workstreams/reference-architectures/README.md
+++ b/workstreams/reference-architectures/README.md
@@ -2,34 +2,87 @@
 
 Workflows & Process Integration WG · Agentic AI Foundation
 
-## What
+## What this workstream is for
 
-A composable catalog of independently adoptable components for agentic workflows, plus one reference architecture per use case. Components first; architectures derived from use cases. Not a monolithic RA. Charter deliverable target: 08.01.2026.
+Produce the workflow reference architecture for agent workflow execution.
+
+Start with two generic reference architectures:
+
+- **single-agent workflow**
+- **multi-agent workflow**
+
+Scenarios validate and illustrate the reference architectures. If a scenario does not fit either generic architecture, that is a signal that a new reference architecture may be needed.
+
+## Guidelines
+
+The RA should act as a checklist: a user brings a use case, walks through the right questions, and lands on a pattern.
+
+Include determinism hints: where to use cheap deterministic steps, and where LLM reasoning is worth the cost.
+
+Start with single-agent workflow first. Treat deterministic and ReAct-style internals as equal implementation choices inside the boundary.
+
+Keep the architecture at the component and relationship level.
+
+Use `docs/` for supporting material that informs the reference architectures.
+Use cases and scenarios validate the architectures; they are not separate reference architecture documents.
 
 ## Structure
 
+```text
+workstreams/reference-architectures/
+├── README.md
+├── ra/
+│   ├── ra-single-agent.md
+│   └── ra-multi-agent.md
+├── decisions/
+│   └── TEMPLATE.md
+└── docs/
+    └── *.md
 ```
-./catalog/component-catalog.md   Component blocks, defined once
-./ra/ra-<use-case>.md            One RA per use case
-./templates/ra-template.md       Copy to start a new RA
-./decisions/decision-log.md      Decisions + dates
-```
 
-RA files reference catalog blocks — they don't redefine them.
+## How to read the architectures
 
-## How we work
+A reference architecture should describe:
 
-- Async first. Discord = ideas; Google Doc = proposals; GitHub = artifacts.
-- Contributions happen through PRs: fork the repo, propose changes, discuss on the PR, and merge when ready.
-- Keep artifacts easy to maintain by making ownership clear where useful.
-- Abstraction = components + relationships, not implementation. Properties, not mechanisms.
+- the surrounding workflow pieces
+- how they connect
+- what the agent is allowed to do
+- what must be handled outside the agent
 
-## Contribute
+It should not get into the agent’s internal reasoning loop.
 
-Request repo access in the WG Discord. Copy the template → open a PR → discuss on the PR. Decisions logged in `./decisions/`.
+## Side docs
+
+Use `docs/` for supporting material that helps the workstream but is not itself a reference architecture.
+
+Examples:
+
+- meeting notes and takeaways
+- comparison tables
+- source summaries and reading notes
+- exploratory drafts and hypotheses
+- background research that may later feed a deliverable
+
+If a document is meant to inform the workstream but not define the architecture, put it in `docs/`.
+
+## Working style
+
+- Async first: use PR comments to discuss and converge.
+- Fork-first: contributors work in their own fork or branch and open PRs directly to the workstream destination branch.
+- Keep drafts concise and easy to review.
+- Use decision notes when a choice needs to be recorded.
+- Use TODOs instead of blank sections when something is intentionally unresolved.
+
+## Contribution flow
+
+1. Create or update work in your fork
+2. Open a PR against the workstream destination branch
+3. Discuss and iterate in PR comments
+4. Merge only after the review outcome is clear
 
 ## Links
 
 - WG repo: https://github.com/aaif/wg-workflows-and-process-integration
-- Google Doc: https://docs.google.com/document/d/1g8637JPZZ4Y-V-KXTcGU0de1HmTEc2iI6-PCTHv7zuI/edit?tab=t.s4e90o73aqx5#heading=h.71q4tygpnbxa
+- Charter: [charter.md](../../charter/charter.md)
+- Meeting notes: https://docs.google.com/document/d/1g8637JPZZ4Y-V-KXTcGU0de1HmTEc2iI6-PCTHv7zuI/edit?usp=sharing
 - Discord: https://discord.com/channels/1461090924791595243/1504501906251452478

--- a/workstreams/reference-architectures/README.md
+++ b/workstreams/reference-architectures/README.md
@@ -1,4 +1,4 @@
-# Reference Architecture Workstream
+# Reference Architectures Workstream
 
 Workflows & Process Integration WG · Agentic AI Foundation
 

--- a/workstreams/reference-architectures/decisions/TEMPLATE.md
+++ b/workstreams/reference-architectures/decisions/TEMPLATE.md
@@ -1,0 +1,17 @@
+# Decision Log Template
+
+## Date
+
+TODO
+
+## Decision
+
+TODO
+
+## Rationale
+
+TODO
+
+## Follow-up
+
+TODO

--- a/workstreams/reference-architectures/docs/README.md
+++ b/workstreams/reference-architectures/docs/README.md
@@ -1,0 +1,5 @@
+# Docs
+
+Supporting material for the reference architectures workstream.
+
+Use this folder for background notes, comparisons, source summaries, exploratory drafts, and other supporting material.

--- a/workstreams/reference-architectures/ra/ra-multi-agent.md
+++ b/workstreams/reference-architectures/ra/ra-multi-agent.md
@@ -1,0 +1,19 @@
+# Multi-Agent Workflow
+
+## Status
+
+Draft scaffold. Architecture content to follow in a later PR.
+
+## Purpose
+
+TODO
+
+## Structure
+
+TODO
+
+## Notes
+
+- Keep the architecture at the component and relationship level.
+- Focus on the deterministic boundary around the agent steps.
+- Leave the internal coordination pattern unspecified until the draft is ready.

--- a/workstreams/reference-architectures/ra/ra-single-agent.md
+++ b/workstreams/reference-architectures/ra/ra-single-agent.md
@@ -1,0 +1,19 @@
+# Single-Agent Workflow
+
+## Status
+
+Draft scaffold. Architecture content to follow in a later PR.
+
+## Purpose
+
+TODO
+
+## Structure
+
+TODO
+
+## Notes
+
+- Keep the architecture at the component and relationship level.
+- Focus on the deterministic boundary around the agent step.
+- Leave the agent’s internal reasoning loop unspecified.


### PR DESCRIPTION
## Summary

This PR initializes the Workflows & Process Integration reference architectures workstream with a lean starting structure.

## What’s included

- workstream README for the reference architectures repo area
- placeholder RA drafts for:
  - single-agent workflow
  - multi-agent workflow
- ADR template for decision records
- docs placeholder for supporting material
- root  for local editor/session files

## Workstream framing

The workstream starts with two generic reference architectures:
- single-agent workflow
- multi-agent workflow

Scenarios validate and illustrate the reference architectures. If a scenario does not fit either generic architecture, that is a signal that a new reference architecture may be needed.

The RAs should:
- act as a checklist for choosing the right pattern
- include determinism hints
- keep the architecture at the component and relationship level
- leave internal reasoning loops unspecified

## Notes

This PR is intentionally scaffold-level. It sets up the initial structure for follow-up architecture content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)