### PR TITLE
Add principles and contributor guidance

### DIFF
--- a/workstreams/reference-architectures/AGENTS.md
+++ b/workstreams/reference-architectures/AGENTS.md
@@ -1,0 +1,27 @@
+# Instructions for AI Contributors
+
+Before adding or changing a pattern, reference architecture, scenario, decision, or supporting document in this workstream:
+
+1. Read [README.md](README.md).
+2. Read [CONTRIBUTING.md](CONTRIBUTING.md) completely.
+3. Read the applicable template before drafting:
+   - [patterns/TEMPLATE.md](patterns/TEMPLATE.md)
+   - [architectures/TEMPLATE.md](architectures/TEMPLATE.md)
+
+## Required rules
+
+- A **pattern** solves one independently reusable workflow problem.
+- A **reference architecture** serves a recognizable practitioner job and composes patterns, capability roles, boundaries, guarantees, and exit states.
+- A **scenario** validates an architecture; do not mistake a domain example for the generic architecture name.
+- Reuse existing patterns before proposing a new one.
+- Keep capability descriptions vendor-neutral and at the logical role level.
+- Make the boundary between agent and workflow-controlled work explicit.
+- Do not invent unagreed terminology, standards, or cross-WG controls. Record genuine gaps as open questions.
+- Follow the template’s core section order. Put allowed additional material only after `Open questions` in an explicit `## Appendix: ...` section.
+- State evidence separately from proposed WG interpretation.
+
+Before finishing, complete the self-review checklist in [CONTRIBUTING.md](CONTRIBUTING.md), check internal links, and run:
+
+```bash
+git diff --check
+```

--- a/workstreams/reference-architectures/CONTRIBUTING.md
+++ b/workstreams/reference-architectures/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing Reference Architecture Content
+
+This guide explains how to add or change content in this workstream so that patterns, reference architectures, and validation scenarios remain consistent and reusable.
+
+## Before you write
+
+Read these in order:
+
+1. [README.md](README.md) — the workstream model and current content.
+2. [Job-oriented architecture decision](decisions/job-oriented-architecture-model.md) — the relationship between patterns, architectures, and scenarios.
+3. The applicable template:
+   - [Pattern template](patterns/TEMPLATE.md)
+   - [Architecture template](architectures/TEMPLATE.md)
+
+Reuse existing guidance before proposing a new concept. This workstream is a draft: record genuine gaps as open questions rather than silently inventing new terminology or rules.
+
+## Choose the right contribution type
+
+| If you have… | Add or update… | It is for… |
+|---|---|---|
+| One recurring workflow problem with an independently reusable solution | A **pattern** in `patterns/` | Explaining how to solve that one problem reliably. |
+| A recognizable practitioner job requiring several patterns and capability roles together | A **reference architecture** in `architectures/` | Defining the complete composition, boundaries, guarantees, and exit states for that job. |
+| A real or illustrative workflow example | A **scenario** in an architecture’s `Worked scenario` and `Validation record` sections | Testing whether an architecture fits; it is not an architecture by itself. |
+| Rationale for a structural choice | A **decision note** in `decisions/` | Recording the choice, alternatives, and consequences. |
+| Background research, comparison, or exploratory idea | A document in `docs/` | Informing the workstream without defining the architecture. |
+
+### Pattern or architecture?
+
+A **pattern** solves one sub-problem and can be adopted independently. Examples: a durable wait, a human approval gate, or an independent acceptance check.
+
+A **reference architecture** is the reusable whole for a practitioner job. It composes patterns, capability roles, boundaries, guarantees, and exit states. Its name should complete the sentence:
+
+```text
+“We are building a ___.”
+```
+
+Do not use a domain example as an architecture name unless the job itself is inherently domain-specific. For example, an autonomous maintenance run can validate a broader bounded-autonomous-remediation architecture; it is not automatically the architecture’s name.
+
+## Authoring rules
+
+### For every contribution
+
+- Keep it vendor-neutral. Describe logical capabilities and required behaviour before naming products.
+- State what is known from evidence and what is a proposed WG interpretation. Do not present an unverified implementation claim as fact.
+- Reuse existing patterns and guarantees instead of copying or weakening them.
+- Name cross-cutting concerns owned by another WG as out of scope; do not redefine their standards here.
+- Use plain language first. Define specialized terms where a new reader needs them.
+- Add real open questions rather than filling gaps with invented certainty.
+
+### For a pattern
+
+- Use [`patterns/TEMPLATE.md`](patterns/TEMPLATE.md) in its stated order.
+- Keep the solution small and context-free. If it needs many components or only makes sense as part of one job, it is probably an architecture.
+- State invariants as guarantees that every implementation must preserve.
+- Give concrete failure modes for violated invariants.
+- Distinguish what a runtime mechanism provides from what an implementation must still add.
+
+### For a reference architecture
+
+- Use [`architectures/TEMPLATE.md`](architectures/TEMPLATE.md) in its stated order.
+- Name a reusable practitioner job, not an agent count, vendor, or single example.
+- Compose patterns; do not restate each pattern’s full invariant and failure-mode content.
+- Make the agent/workflow-control boundary explicit: who may propose, decide, authorize, execute, and own state.
+- Describe deterministic versus model-driven work.
+- Define all terminal/exit states and what is recorded for each.
+- Include at least one worked scenario and a validation record. A no-fit or partial-fit result is useful evidence.
+
+### Extra material
+
+Keep the template sections in their stated order. If additional material is genuinely useful, place it after `Open questions` under an explicitly named:
+
+```md
+## Appendix: <topic>
+```
+
+Do not insert new core sections ad hoc.
+
+## Suggested authoring flow
+
+```text
+1. Start with a real problem or scenario.
+2. Check whether an existing pattern or architecture already fits.
+3. Identify the reusable problem or practitioner job—not the domain example.
+4. Draft from the applicable template.
+5. Reuse patterns and state only the new composition-level guarantees.
+6. Add a worked scenario and validation record.
+7. Record uncertainties as open questions.
+8. Run the self-review before opening a PR.
+```
+
+## Self-review checklist
+
+Before opening a PR, confirm:
+
+- [ ] I chose the correct contribution type.
+- [ ] I read the relevant template and retained its core section order.
+- [ ] The name describes a reusable problem or practitioner job, not merely one scenario.
+- [ ] Existing patterns were reused where they fit.
+- [ ] Capability roles are logical and vendor-neutral.
+- [ ] Authority boundaries, external effects, and failure/recovery behaviour are explicit where relevant.
+- [ ] The contribution distinguishes evidence from WG interpretation.
+- [ ] A reference architecture has a scenario-based validation record.
+- [ ] Extra content, if any, is in an explicit appendix.
+- [ ] Internal links resolve and the Markdown has no whitespace errors.
+
+## AI-assisted contributions
+
+AI tools may help draft or review content, but the same rules apply. An AI-generated contribution must identify its evidence, open questions, and assumptions. A human contributor remains responsible for deciding whether the proposed pattern or architecture is correct and reusable.

--- a/workstreams/reference-architectures/README.md
+++ b/workstreams/reference-architectures/README.md
@@ -109,6 +109,10 @@ If a document is meant to inform the workstream but not define the architecture,
 - Use decision notes when a choice needs to be recorded.
 - Use TODOs instead of blank sections when something is intentionally unresolved.
 
+## Principles and contributing
+
+Read [principles.md](principles.md) for the shared design guidance that applies to patterns and reference architectures. For contribution types, templates, and self-review, read [CONTRIBUTING.md](CONTRIBUTING.md). AI coding agents must start with [AGENTS.md](AGENTS.md), which routes them to the same guide and templates.
+
 ## Contribution flow
 
 1. Create or update work in your fork

--- a/workstreams/reference-architectures/principles.md
+++ b/workstreams/reference-architectures/principles.md
@@ -1,0 +1,59 @@
+# Architecture Principles
+
+## Purpose
+
+These principles guide contributors and reviewers when they compose patterns, capability roles, and boundaries into a workflow reference architecture.
+
+They are shared design guidance, not a prescription for a vendor, framework, deployment topology, or model provider. A concrete architecture should show how it applies them; a pattern should support them where relevant.
+
+## 1. Design around practitioner jobs, not agent count
+
+A reference architecture should describe a recognizable job and the guarantees it needs. “Single-agent” and “multi-agent” can be useful design characteristics, but they do not by themselves explain the job, risks, or required structure.
+
+**In practice:** Name an architecture by the outcome or operational arrangement it serves, such as a human-approved operation or bounded autonomous remediation. Treat agent topology as a design decision inside that architecture.
+
+## 2. Prefer the smallest safe amount of autonomy
+
+Use deterministic workflow logic, explicit rules, validation, and policy where they provide the needed behaviour and guarantee. Add model or agent reasoning only where interpretation, judgment, or generation cannot be reliably expressed as rules. Give that reasoning no more authority than the job requires.
+
+**In practice:** Keep admission, scope limits, policy checks, external effects, and terminal outcomes under workflow control. Let an agent interpret open-ended input or produce a candidate result, but do not make it own the whole run by default.
+
+## 3. Make authority and external effects explicit
+
+A workflow should make clear who may propose a result, decide whether it is acceptable, authorize an effect, execute that effect, and own the run state. Those roles may be implemented by one platform, but their responsibilities must remain understandable and enforceable.
+
+**In practice:** An architecture should state what the agent may do and what remains workflow-controlled. Where an effect matters, identify the authority that permits it and the component that performs it.
+
+## 4. Protect consequential effects structurally
+
+A consequential external effect must not depend only on an agent following instructions. The architecture should use enforceable boundaries: a human or policy gate where needed, constrained credentials, a controlled executor, validation, idempotency or reconciliation, and recorded evidence.
+
+**In practice:** An agent may prepare a proposal or candidate result, but it should not be able to bypass the path that authorizes and performs a protected effect.
+
+## 5. Design for failure, recovery, and explicit outcomes
+
+A workflow is not complete when its happy path works. It must define what happens when an input is invalid, a check fails, a process restarts, an event is duplicated or late, an effect result is uncertain, a budget is exhausted, or human intervention is needed.
+
+**In practice:** List terminal outcomes and what is recorded for each. Where the run waits or has effects, explain how state, retries, reconciliation, timeout, stopping, or escalation remain safe.
+
+## 6. Compose reusable patterns; do not duplicate their guarantees
+
+A pattern owns the solution to one recurring problem, including its invariants and failure modes. A reference architecture composes patterns for a practitioner job and describes the new concerns that arise from their combination.
+
+**In practice:** Link to the patterns used and explain where they sit in the architecture. Do not rewrite every pattern inside every architecture. Record only the composition-level risks, such as stale approval after a durable wait or a passing gate that is too weak for the permitted effect.
+
+## 7. Keep requirements portable and implementation-neutral
+
+The reference architecture should describe required behaviour and logical capability roles before product choices. Different runtimes may realize the same roles differently.
+
+**In practice:** Say “durable state store,” “human interaction surface,” or “constrained effect executor,” rather than assuming a particular workflow engine, cloud provider, model host, or deployment topology. Product examples may illustrate an approach but must not become requirements.
+
+## 8. Validate guidance against real scenarios
+
+A scenario is evidence that an architecture fits—or does not fit—a real workflow. It is not automatically a generic reference architecture. No-fit and partial-fit results are valuable because they reveal missing patterns, variants, or new jobs.
+
+**In practice:** Include at least one worked scenario and a validation record in each reference architecture. Keep the generic job, guarantees, and capability roles separate from the domain-specific details of the scenario.
+
+## Applying the principles
+
+When adding or reviewing a reference architecture, look for these principles in its routing checklist, structure, pattern composition, agent/workflow-control boundary, exit states, worked scenario, and validation record. If a principle does not apply, explain why rather than silently omitting it.


### PR DESCRIPTION
## Summary

Adds shared principles and a consistent authoring path for future Reference
Architecture contributions.

The goal is to make the workstream a shared WG asset: contributors should be
able to tell whether they are adding a pattern, a job-oriented reference
architecture, a validation scenario, a decision, or supporting material - and
use the same expected structure and review rules.

## Adds

### Architecture principles

`principles.md` provides concise shared design guidance for patterns and
reference architectures:

- design around practitioner jobs, not agent count;
- prefer the smallest safe amount of autonomy;
- make authority and external effects explicit;
- protect consequential effects structurally;
- design for failure, recovery, and explicit outcomes;
- compose reusable patterns rather than duplicating their guarantees;
- keep requirements portable and implementation-neutral;
- validate guidance against real scenarios.

### Contributor guidance

- `CONTRIBUTING.md` defines contribution types, pattern-versus-architecture
  criteria, template use, authoring rules, and a self-review checklist.
- `AGENTS.md` gives AI coding agents concise instructions that route them
  through the same guide and templates.
- `README.md` links to the principles and contribution path.

## Scope

This PR does not introduce a primitive catalog, capability catalog, taxonomy,
short codes, machine-readable schema, or conformance process. It establishes
shared authoring guidance so those future additions can be contributed and
reviewed consistently.
